### PR TITLE
Deprecate NodeJS carbon support - End of life

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: node_js
 node_js:
   - "node"
   - "lts/*"
-  - "lts/carbon"
+  - "lts/fermium"
+  - "lts/erbium"
+  - "lts/dubnium"


### PR DESCRIPTION
End of life for NodeJS Carbon release
Remove LTS/carbon from CI tests
